### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/856/323/37/85632337.geojson
+++ b/data/856/323/37/85632337.geojson
@@ -229,6 +229,9 @@
         "qs:id":1209134
     },
     "wof:country":"TF",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc79196558453942c5af83b544593bf2",
     "wof:hierarchy":[
         {
@@ -238,7 +241,7 @@
         }
     ],
     "wof:id":85632337,
-    "wof:lastmodified":1561751410,
+    "wof:lastmodified":1582347814,
     "wof:name":"Bassas da India",
     "wof:parent_id":85633147,
     "wof:placetype":"dependency",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.