### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/890/431/493/890431493.geojson
+++ b/data/890/431/493/890431493.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:afr_x_preferred":[
+        "Port-aux-Fran\u00e7ais"
+    ],
     "name:bre_x_preferred":[
         "Port-aux-Fran\u00e7ais"
     ],
@@ -34,7 +37,13 @@
     "name:eng_x_preferred":[
         "Port-aux-Fran\u00e7ais"
     ],
+    "name:fin_x_preferred":[
+        "Port-aux-Fran\u00e7ais"
+    ],
     "name:fra_x_preferred":[
+        "Port-aux-Fran\u00e7ais"
+    ],
+    "name:hat_x_preferred":[
         "Port-aux-Fran\u00e7ais"
     ],
     "name:heb_x_preferred":[
@@ -57,6 +66,9 @@
     ],
     "name:lit_x_preferred":[
         "Port o Frans\u0117"
+    ],
+    "name:mkd_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u043e-\u0424\u0440\u0430\u043d\u0441\u0435"
     ],
     "name:nld_x_preferred":[
         "Port-aux-Fran\u00e7ais"
@@ -133,7 +145,7 @@
         }
     ],
     "wof:id":890431493,
-    "wof:lastmodified":1566654215,
+    "wof:lastmodified":1690868593,
     "wof:name":"Port-aux-Fran\u00e7ais",
     "wof:parent_id":85668143,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.