### PR TITLE
tf concordances, placetype local, and more

### DIFF
--- a/data/856/681/43/85668143.geojson
+++ b/data/856/681/43/85668143.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.863696,
-    "geom:area_square_m":6964745232.514854,
+    "geom:area_square_m":6964746222.288415,
     "geom:bbox":"68.610118,-49.721612,70.568533,-48.566664",
     "geom:latitude":-49.296081,
     "geom:longitude":69.488949,
@@ -264,8 +264,9 @@
         "hasc:id":"TF.KG",
         "qs_pg:id":1209134
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TF",
-    "wof:geomhash":"641a446026f0c2444e347c3887d71a4e",
+    "wof:geomhash":"d8b5ee76c2d707a7dbfda3986f04866e",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -280,7 +281,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636501635,
+    "wof:lastmodified":1695884899,
     "wof:name":"Archipel des Kerguelen",
     "wof:parent_id":85632549,
     "wof:placetype":"region",

--- a/data/856/681/49/85668149.geojson
+++ b/data/856/681/49/85668149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02397,
-    "geom:area_square_m":204775256.563456,
+    "geom:area_square_m":204774998.965391,
     "geom:bbox":"50.175548,-46.451267,51.868175,-46.043715",
     "geom:latitude":-46.298377,
     "geom:longitude":51.280621,
@@ -204,8 +204,9 @@
         "hasc:id":"TF.CR",
         "qs_pg:id":1209134
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TF",
-    "wof:geomhash":"62d3365750d27a26d7932ca7eeba1abc",
+    "wof:geomhash":"0cef72761259bdd36e73c11060b90982",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -220,7 +221,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636501636,
+    "wof:lastmodified":1695884899,
     "wof:name":"Archipel des Crozet",
     "wof:parent_id":85632549,
     "wof:placetype":"region",

--- a/data/856/681/53/85668153.geojson
+++ b/data/856/681/53/85668153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006454,
-    "geom:area_square_m":62892581.406178,
+    "geom:area_square_m":62893115.457484,
     "geom:bbox":"77.487559,-38.738458,77.585216,-37.820245",
     "geom:latitude":-37.994101,
     "geom:longitude":77.534773,
@@ -232,8 +232,9 @@
         "hasc:id":"TF.AS",
         "qs_pg:id":1209134
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TF",
-    "wof:geomhash":"162768d1e428e017d968d211eb6a9ff7",
+    "wof:geomhash":"f27a51bf41d922dfc985ddd14e7ca72e",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -248,7 +249,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636501635,
+    "wof:lastmodified":1695884899,
     "wof:name":"Iles Saint-Paul et Nouvelle-Amsterdam",
     "wof:parent_id":85632549,
     "wof:placetype":"region",

--- a/data/856/681/57/85668157.geojson
+++ b/data/856/681/57/85668157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002177,
-    "geom:area_square_m":25154983.127643,
+    "geom:area_square_m":25154941.292419,
     "geom:bbox":"39.69394,-22.365492,54.521332,-11.550632",
     "geom:latitude":-20.607298,
     "geom:longitude":41.438461,
@@ -204,8 +204,9 @@
         "hasc:id":"TF.IE",
         "qs_pg:id":1209134
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"TF",
-    "wof:geomhash":"b0fe2f999e7b8bfd480847e7665d1089",
+    "wof:geomhash":"4e679efc9b4f92f95567a133d1a28a90",
     "wof:hierarchy":[
         {
             "continent_id":102193527,
@@ -220,7 +221,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636501635,
+    "wof:lastmodified":1695884899,
     "wof:name":"Iles Eparses de l'ocean Indien",
     "wof:parent_id":85632549,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.